### PR TITLE
Ensure data is available on binary sensors

### DIFF
--- a/custom_components/renault/binary_sensor.py
+++ b/custom_components/renault/binary_sensor.py
@@ -51,11 +51,11 @@ class RenaultPluggedInSensor(RenaultBatteryDataEntity, BinarySensorEntity):
     @property
     def is_on(self) -> Optional[bool]:
         """Return true if the binary sensor is on."""
-        return (
-            self.data.get_plug_status() == PlugState.PLUGGED
-            if self.data.plugStatus is not None
-            else None
-        )
+        if not self.data:
+            return None
+        if self.data.plugStatus is None:
+            return None
+        return self.data.get_plug_status() == PlugState.PLUGGED
 
     @property
     def icon(self) -> str:
@@ -76,11 +76,11 @@ class RenaultChargingSensor(RenaultBatteryDataEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
-        return (
-            self.data.get_charging_status() == ChargeState.CHARGE_IN_PROGRESS
-            if self.data.chargingStatus is not None
-            else None
-        )
+        if not self.data:
+            return None
+        if self.data.chargingStatus is None:
+            return None
+        return self.data.get_charging_status() == ChargeState.CHARGE_IN_PROGRESS
 
     @property
     def icon(self) -> str:

--- a/custom_components/renault/binary_sensor.py
+++ b/custom_components/renault/binary_sensor.py
@@ -51,9 +51,7 @@ class RenaultPluggedInSensor(RenaultBatteryDataEntity, BinarySensorEntity):
     @property
     def is_on(self) -> Optional[bool]:
         """Return true if the binary sensor is on."""
-        if not self.data:
-            return None
-        if self.data.plugStatus is None:
+        if (not self.data) or (self.data.plugStatus is None):
             return None
         return self.data.get_plug_status() == PlugState.PLUGGED
 
@@ -76,9 +74,7 @@ class RenaultChargingSensor(RenaultBatteryDataEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
-        if not self.data:
-            return None
-        if self.data.chargingStatus is None:
+        if (not self.data) or (self.data.chargingStatus is None):
             return None
         return self.data.get_charging_status() == ChargeState.CHARGE_IN_PROGRESS
 


### PR DESCRIPTION
It seems that `available` property of `DataUpdateCoordinator` is not checked when `is_on` is called.
So when `self.data is None`, it is currently generating errors in logs.
