### PR TITLE
Bump renault api to v0.0.4

### DIFF
--- a/custom_components/renault/manifest.json
+++ b/custom_components/renault/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/hacf-fr/hassRenaultZE",
   "issue_tracker": "https://github.com/hacf-fr/hassRenaultZE/issues",
   "requirements": [
-    "renault-api==0.0.3"
+    "renault-api==0.0.4"
   ],
   "codeowners": [
     "@epenet"

--- a/custom_components/renault/translations/sensor.en.json
+++ b/custom_components/renault/translations/sensor.en.json
@@ -3,16 +3,18 @@
     "renault__plug_state": {
       "unplugged": "Unplugged",
       "plugged": "Plugged in",
-      "plug_error": "Plug error"
+      "plug_error": "Plug error",
+      "plug_unknown": "Plug unknown"
     },
     "renault__charge_state": {
       "not_in_charge": "Not charging",
-      "waiting_for_planned_charge": "Waiting for planned charge",
+      "waiting_for_a_planned_charge": "Waiting for planned charge",
       "charge_ended": "Charge ended",
       "waiting_for_current_charge": "Waiting for current charge",
       "energy_flap_opened": "Energy flap opened",
       "charge_in_progress": "Charging",
-      "charge_error": "Not charging or plugged in"
+      "charge_error": "Not charging or plugged in",
+      "unavailable": "Unavailable"
     },
     "renault__charge_mode": {
       "always": "Instant",

--- a/custom_components/renault/translations/sensor.fr.json
+++ b/custom_components/renault/translations/sensor.fr.json
@@ -3,16 +3,18 @@
     "renault__plug_state": {
       "unplugged": "Débranché",
       "plugged": "Branché",
-      "plug_error": "Erreur prise"
+      "plug_error": "Erreur prise",
+      "plug_unknown": "Prise inconnue"
     },
     "renault__charge_state": {
       "not_in_charge": "Pas de charge",
-      "waiting_for_planned_charge": "En attente pour la charge programmée",
+      "waiting_for_a_planned_charge": "En attente pour la charge programmée",
       "charge_ended": "Charge terminée",
       "waiting_for_current_charge": "En attente du courant de charge",
       "energy_flap_opened": "Trappe de charge ouverte",
       "charge_in_progress": "En charge",
-      "charge_error": "Pas de charge ou débranchée"
+      "charge_error": "Pas de charge ou débranchée",
+      "unavailable": "Indisponible"
     },
     "renault__charge_mode": {
       "always": "Instantanée",


### PR DESCRIPTION
Release history:
https://github.com/hacf-fr/renault-api/releases/tag/v0.0.4