### PR TITLE
Update `charge_set_schedule` template

### DIFF
--- a/custom_components/renault/services.yaml
+++ b/custom_components/renault/services.yaml
@@ -43,4 +43,4 @@ charge_set_schedules:
       example: "VF1xxxxxxxxxxxxxx"
     schedules:
       description: Schedule details.
-      example: "{'id':1,'activated':true,'monday':{'startTime':'T12:00Z','duration':15},'tuesday':{'startTime':'T12:00Z','duration':15},'wednesday':{'startTime':'T12:00Z','duration':15},'thursday':{'startTime':'T12:00Z','duration':15},'friday':{'startTime':'T12:00Z','duration':15},'saturday':{'startTime':'T12:00Z','duration':15},'sunday':{'startTime':'T04:30Z','duration':420}}"
+      example: "{'id':1,'activated':true,'monday':{'startTime':'T12:00Z','duration':15},'tuesday':{'startTime':'T12:00Z','duration':15},'wednesday':{'startTime':'T12:00Z','duration':15},'thursday':{'startTime':'T12:00Z','duration':15},'friday':{'startTime':'T12:00Z','duration':15},'saturday':{'startTime':'T12:00Z','duration':15},'sunday':{'startTime':'T12:00Z','duration':15}}"


### PR DESCRIPTION
Relates to #105 

It seems that Zoe40 (which has only one schedule allowed) allows separate days to be different.
However Zoe50 (which has multiple schedules allowed) requires all startTime to be the same in a single schedule.