### PR TITLE
Bump renault-api to v0.1.0

### DIFF
--- a/custom_components/renault/manifest.json
+++ b/custom_components/renault/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/hacf-fr/hassRenaultZE",
   "issue_tracker": "https://github.com/hacf-fr/hassRenaultZE/issues",
   "requirements": [
-    "renault-api==0.0.4"
+    "renault-api==0.1.0"
   ],
   "codeowners": [
     "@epenet"

--- a/custom_components/renault/renault_vehicle.py
+++ b/custom_components/renault/renault_vehicle.py
@@ -21,7 +21,7 @@ class RenaultVehicleProxy:
         self,
         hass: HomeAssistantType,
         vehicle: RenaultVehicle,
-        details: models.KamereonVehiclesDetails,
+        details: models.KamereonVehicleDetails,
         scan_interval: timedelta,
         distances_in_miles: bool,
     ) -> None:
@@ -42,7 +42,7 @@ class RenaultVehicleProxy:
         self._distances_in_miles = distances_in_miles
 
     @property
-    def details(self) -> models.KamereonVehiclesDetails:
+    def details(self) -> models.KamereonVehicleDetails:
         """Return the specs of the vehicle."""
         return self._details
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-renault-api==0.0.1.dev1606315769
+renault-api==0.1.0


### PR DESCRIPTION
Release history:
https://github.com/hacf-fr/renault-api/releases/tag/v0.1.0