### PR TITLE
Add documentation about hvac limitation on ZE50

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -3,7 +3,7 @@
 The component is generic and tries to adapt to all supported models. It is mostly configured via the UI however, due to limitations on the Renault API, some features may need to be configured manually.
 
 ## HVAC
-Hvac status is not available for Zoe50 (model code X102VE). But Starting HVAC is possible with service `renault.ac_start`.
+On some models (eg. Zoe40), HVAC status always reports as off. On other models (eg. Zoe50) it is not available at all. HVAC control is therefore not available as a standard climate entity, but needs to be controlled via a service call to `renault.ac_start`.
 
 The service `renault.ac_stop` does not provide errors, but it is assumed that is as no effect on the vehicle.
 Following MyRenaultApp documentation, HVAC is started between 5 and 50 min.

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -5,7 +5,7 @@ The component is generic and tries to adapt to all supported models. It is mostl
 ## HVAC
 On some models (eg. Zoe40), HVAC status always reports as off. On other models (eg. Zoe50) it is not available at all. HVAC control is therefore not available as a standard climate entity, but needs to be controlled via a service call to `renault.ac_start`.
 
-The service `renault.ac_stop` does not provide errors, but it is assumed that is as no effect on the vehicle.
+Please note that the service `renault.ac_stop` does not provide errors, but appears to have no effect on some models.
 Following MyRenaultApp documentation, HVAC is started between 5 and 50 min.
 
 This is an example script to start HVAC for Zoe50 :

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -42,7 +42,7 @@ switch:
       zoe_ac_start:
         friendly_name: "A/C"
         icon_template: mdi:fan
-        value_template: "{{ is_state('script.zoe_ac_start', 'on') }}"
+        value_template: "{{ is_state('script.start_hvac', 'on') }}"
         turn_on:
           service: homeassistant.turn_on
           data:

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -1,4 +1,4 @@
-# Limitations
+# Configuration
 
 The component tends to be generic and adapt to all supported models. However, Renault locks or limit some functionnalities based on vehicle model.
 This page list them.

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -8,7 +8,7 @@ On some models (eg. Zoe40), HVAC status always reports as off. On other models (
 Please note that the service `renault.ac_stop` does not provide errors, but appears to have no effect on some models.
 Following MyRenaultApp documentation, HVAC is started between 5 and 50 min.
 
-This is an example script to start HVAC for Zoe50 :
+This is an example script to start HVAC :
 ```yaml
 # Scripts
 script:

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -1,0 +1,55 @@
+# Limitations
+
+The component tends to be generic and adapt to all supported models. However, Renault locks or limit some functionnalities based on vehicle model.
+This page list them.
+
+## HVAC
+Hvac status is not available for Zoe50 (model code X102VE). But Starting HVAC is possible with service `renault.ac_start`.
+
+The service `renault.ac_stop` does not provide errors, but it is assumed that is as no effect on the vehicle.
+Following MyRenaultApp documentation, HVAC is started between 5 and 50 min.
+
+This is an example script to start HVAC for Zoe50 :
+```yaml
+# Scripts
+script:
+  start_hvac:
+  alias: Start HVAC
+  sequence:
+  - service: renault.ac_start
+      data:
+      vin: VF1xxxxxxx
+      temperature: 21
+  # optional notification to device
+  - device_id: xxxxxxxxxxxxx
+    domain: mobile_app
+    type: notify
+    message: Starting HVAC at 21°C
+    title: Renault ZOE
+  # optional delay to avoid multiple launch 
+  - delay:
+      seconds: 300
+  mode: single
+  icon: mdi:snowflake
+```
+
+This is and example of switch :
+```yaml
+# Switches
+switch:
+  - platform: template
+    switches:
+      # Start AC now for five minutes (see script)
+      zoe_ac_start:
+        friendly_name: "A/C"
+        icon_template: mdi:fan
+        value_template: "{{ is_state('script.zoe_ac_start', 'on') }}"
+        turn_on:
+          service: homeassistant.turn_on
+          data:
+            entity_id: script.start_hvac
+        turn_off:
+          service: homeassistant.turn_off
+          data:
+            entity_id: script.start_hvac
+```

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -1,7 +1,6 @@
 # Configuration
 
-The component tends to be generic and adapt to all supported models. However, Renault locks or limit some functionnalities based on vehicle model.
-This page list them.
+The component is generic and tries to adapt to all supported models. It is mostly configured via the UI however, due to limitations on the Renault API, some features may need to be configured manually.
 
 ## HVAC
 Hvac status is not available for Zoe50 (model code X102VE). But Starting HVAC is possible with service `renault.ac_start`.

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -32,7 +32,7 @@ script:
   icon: mdi:snowflake
 ```
 
-This is and example of switch :
+This is an example of a fake switch, whose state will match whether the script is still running (ie. was started less than 300 seconds ago) :
 ```yaml
 # Switches
 switch:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ custom_components/renault/services.yaml
 custom_components/renault/strings.json
 ```
 
-## Configuration is done in the UI
+## Configuration
+Configuration is done in the UI, but some cases needs [specific configuration](CONFIGURE.md).
 
-<!---->
 
 ## Logging
 If you are having issues with the component, please enable debug logging in your `configuration.yaml`, for example:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ custom_components/renault/strings.json
 ```
 
 ## Configuration
-Configuration is done in the UI, but some cases needs [specific configuration](CONFIGURE.md).
+Configuration is done in the UI, but some cases need [specific configuration](CONFIGURE.md).
 
 
 ## Logging


### PR DESCRIPTION
Following #51 : having HVAC status does not work for the ZE50 model causes returns of issues.
Climate entity is now disabled for this model and some documentation could help user to use `renault.ac_start` service as this one works.