### PR TITLE
Deprecate the custom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # renault
 
+# :warning: The Renault integration was originally merged into core in 2021.8 and finalised in 2021.10. The use of this custom component has been deprecated since then and should no longer be used
+
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
 [![License][license-shield]](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # renault
 
-# :warning: The Renault integration was originally merged into core in 2021.8 and finalised in 2021.10. The use of this custom component has been deprecated since then and should no longer be used
-
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
 [![License][license-shield]](LICENSE)
@@ -13,6 +11,8 @@
 [![Community Forum][forum-shield]][forum]
 
 _Component to integrate with [Renault][renault]._
+
+# :warning: The Renault integration was originally merged into core in 2021.8 and finalised in 2021.10. The use of this custom component has been deprecated since then and should no longer be used
 
 **This component will set up the following platforms.**
 

--- a/custom_components/renault/__init__.py
+++ b/custom_components/renault/__init__.py
@@ -1,17 +1,28 @@
 """Support for Renault devices."""
 import aiohttp
+from awesomeversion import AwesomeVersion
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import __version__, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import HomeAssistantType
+import logging
+
 
 from .const import CONF_LOCALE, DOMAIN, SUPPORTED_PLATFORMS
 from .renault_hub import RenaultHub
 from .services import async_setup_services, async_unload_services
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup(hass, config):
     """Set up renault integrations."""
+    if AwesomeVersion(__version__) >= "2021.10.0b0":
+        _LOGGER.error(
+            "The Renault integration was originally merged into core in 2021.8 "
+            "and finalised in 2021.10. The use of this custom component has been "
+            "deprecated since then and should be removed from your installation"
+        )
     return True
 
 


### PR DESCRIPTION
⚠️ The Renault integration was originally merged into core in 2021.8 and finalised in 2021.10. The use of this custom component has been deprecated since then and should no longer be used